### PR TITLE
chore: upgrade openssl and tokio to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ firestore = { version = "0.48.0", features = ["caching-memory"] }
 futures = "0.3.32"
 itertools = "0.14.0"
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
-openssl = { version = "0.10.76", features = ["vendored"] }
+openssl = { version = "0.10.78", features = ["vendored"] }
 reqwest = { version = "0.13.2", features = ["form"] }
 rustls = { version = "0.23.38", features = ["aws-lc-rs"] }
 serde = {version = "1.0.228", features = ["derive"]}
 serde_json = "1.0.149"
-tokio = { version = "1.51.0", features = ["sync"] }
+tokio = { version = "1.52.1", features = ["sync"] }
 
 [dev-dependencies]
 tokio-shared-rt = "0.1.0"


### PR DESCRIPTION
## Summary

Upgrade dependencies to their latest versions:

- **openssl**: 0.10.76 → 0.10.78
- **tokio**: 1.51.0 → 1.52.1

No changes needed to other dependencies as they are already on latest versions.

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)